### PR TITLE
Add vet availability scheduling and bookable time slots

### DIFF
--- a/frontend/src/components/MakeAppointment.jsx
+++ b/frontend/src/components/MakeAppointment.jsx
@@ -5,17 +5,26 @@ import { FaCalendarCheck, FaCalendarPlus } from 'react-icons/fa'
 
 const MakeAppointment = () => {
   const { vetId } = useParams()
-  const { vets, addAppointment } = useContext(VetContext)
+  const { vets, appointments, addAppointment } = useContext(VetContext)
   const vet = vets.find(v => v.id === vetId)
   const [userName, setUserName] = useState('')
-  const [date, setDate] = useState('')
+  const [selectedDate, setSelectedDate] = useState('')
+  const [time, setTime] = useState('')
   const navigate = useNavigate()
 
   if (!vet) return <p>Vet not found.</p>
 
+  const availability = vet.availability || {}
+  const slotsForDate = availability[selectedDate] || []
+  const bookedSlots = appointments
+    .filter(a => a.vetId === vetId && a.date.startsWith(selectedDate))
+    .map(a => a.date.slice(11, 16))
+  const freeSlots = slotsForDate.filter(s => !bookedSlots.includes(s))
+
   const handleSubmit = e => {
     e.preventDefault()
-    addAppointment({ vetId, userName, date })
+    if (!time) return
+    addAppointment({ vetId, userName, date: `${selectedDate}T${time}` })
     navigate('/')
   }
 
@@ -35,10 +44,27 @@ const MakeAppointment = () => {
       />
       <input
         className="w-full rounded border p-2"
-        type="datetime-local"
-        value={date}
-        onChange={e => setDate(e.target.value)}
+        type="date"
+        value={selectedDate}
+        onChange={e => {
+          setSelectedDate(e.target.value)
+          setTime('')
+        }}
       />
+      {selectedDate && (
+        <select
+          className="w-full rounded border p-2"
+          value={time}
+          onChange={e => setTime(e.target.value)}
+        >
+          <option value="">Select Time</option>
+          {freeSlots.map(slot => (
+            <option key={slot} value={slot}>
+              {slot}
+            </option>
+          ))}
+        </select>
+      )}
       <button
         className="flex items-center gap-2 rounded bg-blue-600 px-4 py-2 text-white"
         type="submit"

--- a/frontend/src/components/VetDashboard.jsx
+++ b/frontend/src/components/VetDashboard.jsx
@@ -1,26 +1,91 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import { VetContext } from '../context/VetContext'
 import { FaCalendarAlt } from 'react-icons/fa'
 
 const VetDashboard = () => {
-  const { currentVet, appointments } = useContext(VetContext)
+  const { currentVet, appointments, setAvailability } = useContext(VetContext)
+  const [date, setDate] = useState('')
+  const [start, setStart] = useState('')
+  const [end, setEnd] = useState('')
 
   if (!currentVet) return <p>Please log in as a vet.</p>
 
   const myAppointments = appointments.filter(a => a.vetId === currentVet.id)
+  const availability = currentVet.availability || {}
+
+  const generateSlots = (s, e) => {
+    const slots = []
+    let current = new Date(`1970-01-01T${s}`)
+    const endDate = new Date(`1970-01-01T${e}`)
+    while (current < endDate) {
+      slots.push(current.toTimeString().slice(0, 5))
+      current = new Date(current.getTime() + 30 * 60000)
+    }
+    return slots
+  }
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    if (!date || !start || !end) return
+    const slots = generateSlots(start, end)
+    setAvailability(date, slots)
+    setDate('')
+    setStart('')
+    setEnd('')
+  }
 
   return (
-    <div className="mx-auto max-w-md rounded bg-white p-6 shadow">
-      <h2 className="mb-4 flex items-center text-2xl font-bold">
-        <FaCalendarAlt className="mr-2" /> {currentVet.name} {currentVet.lastName || ''}'s Appointments
-      </h2>
-      <ul className="space-y-2">
-        {myAppointments.map(a => (
-          <li className="rounded border p-2" key={a.id}>
-            {a.userName} - {a.date}
-          </li>
-        ))}
-      </ul>
+    <div className="mx-auto max-w-md rounded bg-white p-6 shadow space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <h3 className="text-xl font-bold">Set Availability</h3>
+        <input
+          type="date"
+          className="w-full rounded border p-2"
+          value={date}
+          onChange={e => setDate(e.target.value)}
+        />
+        <div className="flex gap-2">
+          <input
+            type="time"
+            className="flex-1 rounded border p-2"
+            value={start}
+            onChange={e => setStart(e.target.value)}
+          />
+          <input
+            type="time"
+            className="flex-1 rounded border p-2"
+            value={end}
+            onChange={e => setEnd(e.target.value)}
+          />
+        </div>
+        <button className="rounded bg-blue-600 px-4 py-2 text-white" type="submit">
+          Save
+        </button>
+      </form>
+      {Object.keys(availability).length > 0 && (
+        <div>
+          <h3 className="mb-2 text-xl font-bold">Current Availability</h3>
+          <ul className="space-y-1">
+            {Object.entries(availability).map(([d, slots]) => (
+              <li key={d} className="rounded border p-2">
+                {d}: {slots.join(', ')}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div>
+        <h2 className="mb-4 flex items-center text-2xl font-bold">
+          <FaCalendarAlt className="mr-2" /> {currentVet.name} {currentVet.lastName || ''}'s Appointments
+        </h2>
+        <ul className="space-y-2">
+          {myAppointments.map(a => (
+            <li className="rounded border p-2" key={a.id}>
+              {a.userName} - {a.date}
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   )
 }

--- a/frontend/src/context/VetContext.jsx
+++ b/frontend/src/context/VetContext.jsx
@@ -47,6 +47,18 @@ export const VetProvider = ({ children }) => {
     setCurrentVet(updated)
   }
 
+  const setAvailability = (date, slots) => {
+    const updated = {
+      ...currentVet,
+      availability: {
+        ...(currentVet?.availability || {}),
+        [date]: slots,
+      },
+    }
+    setVets(vets.map(v => (v.id === currentVet.id ? updated : v)))
+    setCurrentVet(updated)
+  }
+
   const addAppointment = appt => {
     setAppointments([...appointments, { ...appt, id: Date.now().toString() }])
   }
@@ -61,6 +73,7 @@ export const VetProvider = ({ children }) => {
         loginVet,
         logoutVet,
         updateVet,
+        setAvailability,
         addAppointment,
       }}
     >


### PR DESCRIPTION
## Summary
- allow veterinarians to define daily availability slots in 30-minute intervals
- expose availability settings in vet dashboard and show existing availability
- limit appointment booking to free slots and prevent selecting booked times

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9e23abd84832e99a3f5335180c317